### PR TITLE
Include authorization header in request if present

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -315,4 +315,45 @@ describe('doxie go JSON API', () => {
       });
     });
   });
+
+  describe('axios_instance', () => {
+    const baseApiUrl = 'https://www.fake.url';
+    const basePort = 8080;
+    let doxie;
+
+    beforeEach(() => {
+      // https://github.com/nock/nock#disabling-requests
+      nock.disableNetConnect();
+      doxie = new doxieNode({
+        username: 'doxie',
+        password: 'password1',
+        doxieURL: baseApiUrl,
+        doxiePort: basePort
+      });
+    });
+
+    it('should set Authorization header on instance if token exists', () => {
+      doxie.getInitializedApi();
+      expect(doxie.axiosInstance).not.toBeNull();
+      expect(
+        doxie.axiosInstance.defaults.headers.Authorization
+      ).not.toBeUndefined();
+    });
+
+    it('should include Authorization header on requests if present', () => {
+      let authHeader;
+      nock(`${baseApiUrl}:${basePort}`, {
+        reqheaders: {
+          Authorization: headerValue => (authHeader = headerValue)
+        }
+      })
+        .get('/hello.json')
+        .reply(200);
+
+      return doxie.hello().then(() => {
+        expect(authHeader).not.toBeNull();
+        expect(authHeader).not.toBeUndefined();
+      });
+    });
+  });
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,9 +42,11 @@ class doxieNode {
 
   getInitializedApi() {
     if (this.axiosInstance) return this.axiosInstance;
-    return (this.axiosInstance = axios.create({
+    let axiosDefault = {
       baseURL: this.getBaseURL()
-    }));
+    };
+    if (this.token) axiosDefault.headers = { Authorization: this.token };
+    return (this.axiosInstance = axios.create(axiosDefault));
   }
 
   async get(url, responseType = 'application/json', ...args) {


### PR DESCRIPTION
For #10 

Adds authorization header to `axiosInstance` and includes them in requests when present.